### PR TITLE
Fix: Correct package name for UserController

### DIFF
--- a/src/main/java/cpl/airline_booking_backend/controllers/UserController.java
+++ b/src/main/java/cpl/airline_booking_backend/controllers/UserController.java
@@ -1,4 +1,4 @@
-package cpl.airline_booking_backend.controller;
+package cpl.airline_booking_backend.controllers;
 
 import cpl.airline_booking_backend.dao.UserDAO;
 import cpl.airline_booking_backend.model.User;


### PR DESCRIPTION
The UserController was in the 'cpl.airline_booking_backend.controller' package, but the directory structure was 'cpl/airline_booking_backend/controllers/'.

This commit changes the package declaration in UserController.java to 'cpl.airline_booking_backend.controllers' to match the directory structure. This allows Spring's component scan to discover and register the UserController, making its @RequestMapping endpoints available.